### PR TITLE
Added multiple arguments handling, fixed crash on service messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ node-telegram-bot
 
 ## Changelog
 
+- 0.0.17 support multiple command arguments
 - 0.0.16 support file id for audio, document, sticker and video
 - 0.0.15 emit command (message that starts with '/')
 - 0.0.14 sendLocation

--- a/examples/echoBotExample.js
+++ b/examples/echoBotExample.js
@@ -40,7 +40,7 @@ var bot = new Bot({
 
     })
 	//Command without argument
-	.on('test', function(command, msg){
+	.on('test', function(msg){
 		bot.sendMessage({
 			chat_id: msg.chat.id,
 			text: 'You\'ve send command: ' + command

--- a/examples/echoBotExample.js
+++ b/examples/echoBotExample.js
@@ -47,10 +47,10 @@ var bot = new Bot({
 		});
 	})
 	//Command with argument:
-	.on('arg', function(argument, msg){
+	.on('arg', function(args, msg){
 		bot.sendMessage({
 			chat_id: msg.chat.id,
-			text: 'You\'ve send command with argument: ' + argument
+			text: 'You\'ve send command with arguments: ' + args
 		});
 	})
     .start();

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -9,16 +9,6 @@ var EventEmitter = require('events').EventEmitter
 
 // request.debug = true;
 
-/**
- * Constructor for Telegram Bot API Client.
- *
- * @class Bot
- * @constructor
- * @param {Object} options        Configurations for the client
- * @param {String} options.token  Bot token
- * 
- * @see https://core.telegram.org/bots/api
- */
 function Bot(options) {
   this.base_url = 'https://api.telegram.org/bot';
   this.polling = false;
@@ -30,14 +20,6 @@ function Bot(options) {
 }
 
 util.inherits(Bot, EventEmitter);
-
-/**
- * This callback occur after client request for a certain webservice.
- * 
- * @callback Bot~requestCallback
- * @param {Error}   Error during request
- * @param {Object}  Response from Telegram service
- */
 
 Bot.prototype._get = function (options, callback) {
   var url = this.base_url + this.token + '/' + options.method;
@@ -105,21 +87,19 @@ Bot.prototype._poll = function () {
         body.result.forEach(function (msg) {
           if (msg.update_id >= self.offset) {
             self.offset = msg.update_id + 1;
-
-            if (msg.message.text) {
-              var command = msg.message.text.split(' ', 2)[0];
-              if (command.charAt(0) === '/') {
-                command = command.replace(/[^a-zA-Z0-9 ]/g, "");
-                //TODO add multiple arguments recognition
-                if(msg.message.text.split(' ', 2)[1])
-                {
-                  self.emit(command, msg.message.text.split(' ', 2)[1], msg.message);
-                } else{
-                  self.emit(command, msg.message.text, msg.message);
-                }
-              }
-            }
-            
+	        if(msg.message.text.charAt(0) === '/'){
+		        var command = msg.message.text.split(' ', 2)[0];
+		        command = command.replace(/[^a-zA-Z0-9 ]/g, "");
+		        if(msg.message.text.split(' ')[1])
+		        {
+			        var arguments = msg.message.text.split(' ');
+			        arguments.shift();
+			        self.emit(command, arguments, msg.message);
+		        }
+		        else{
+			        self.emit(command, msg.message.text, msg.message);
+		        }
+	        }
             self.emit('message', msg.message);
           }
         });
@@ -135,11 +115,6 @@ Bot.prototype._poll = function () {
   return this;
 };
 
-/**
- * Start polling for messages
- * 
- * @return {Bot} Self
- */
 Bot.prototype.start = function () {
   var self = this;
 
@@ -149,11 +124,6 @@ Bot.prototype.start = function () {
   return self;
 };
 
-/**
- * End polling for messages
- * 
- * @return {Bot} Self
- */
 Bot.prototype.stop = function () {
   var self = this;
   
@@ -162,14 +132,6 @@ Bot.prototype.stop = function () {
   return self;
 };
 
-/**
- * Returns basic information about the bot in form of a User object.
- * 
- * @param {Bot~requestCallback} callback    The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#getme
- */
 Bot.prototype.getMe = function (callback) {
   var self = this
     , deferred = Q.defer();
@@ -193,18 +155,6 @@ Bot.prototype.getMe = function (callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to get a list of profile pictures for a user. 
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.user_id   Unique identifier of the target user
- * @param {String=}             options.offset    Sequential number of the first photo to be returned. By default, all photos are returned.
- * @param {Integer=}            options.limit     Limits the number of photos to be retrieved. Values between 1—100 are accepted. Defaults to 100.
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#getuserprofilephotos
- */
 Bot.prototype.getUserProfilePhotos = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -231,20 +181,6 @@ Bot.prototype.getUserProfilePhotos = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send text messages.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.text      Text of the message to be sent
- * @param {Boolean=}            options.disable_web_page_preview    Disables link previews for links in this message
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendmessage
- */
 Bot.prototype.sendMessage = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -273,18 +209,6 @@ Bot.prototype.sendMessage = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to forward messages of any kind.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {Integer}             options.from_chat_id    Unique identifier for the chat where the original message was sent — User or GroupChat id
- * @param {Integer}             options.message_id    Unique message identifier
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#forwardmessage
- */
 Bot.prototype.forwardMessage = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -311,21 +235,6 @@ Bot.prototype.forwardMessage = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send photos. 
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.photo     Path to photo file (Library will create a stream if the path exist)
- * @param {String=}             options.file_id   If file_id is passed, method will use this instead
- * @param {String=}             options.caption   Photo caption (may also be used when resending photos by file_id).
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendphoto
- */
 Bot.prototype.sendPhoto = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -379,20 +288,6 @@ Bot.prototype.sendPhoto = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.audio     Path to audio file (Library will create a stream if the path exist)
- * @param {String=}             options.file_id   If file_id is passed, method will use this instead
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendaudio
- */
 Bot.prototype.sendAudio = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -449,20 +344,6 @@ Bot.prototype.sendAudio = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send general files. 
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.document  Path to document file (Library will create a stream if the path exist)
- * @param {String=}             options.file_id   If file_id is passed, method will use this instead
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#senddocument
- */
 Bot.prototype.sendDocument = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -514,20 +395,6 @@ Bot.prototype.sendDocument = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send .webp stickers.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.sticker   Path to sticker file (Library will create a stream if the path exist)
- * @param {String=}             options.file_id   If file_id is passed, method will use this instead
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendsticker
- */
 Bot.prototype.sendSticker = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -584,20 +451,6 @@ Bot.prototype.sendSticker = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send video files, Telegram clients support mp4 video.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.video   Path to video file (Library will create a stream if the path exist)
- * @param {String=}             options.file_id   If file_id is passed, method will use this instead
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendvideo
- */
 Bot.prototype.sendVideo = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -654,20 +507,6 @@ Bot.prototype.sendVideo = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method to send point on the map.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {Float}               options.latitude  Latitude of location
- * @param {Float}               options.longitude Longitude of location
- * @param {Integer=}            options.reply_to_message_id   If the message is a reply, ID of the original message
- * @param {Object=}             options.reply_markup    Additional interface options. {@link https://core.telegram.org/bots/api/#replykeyboardmarkup| ReplyKeyboardMarkup}
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendlocation
- */
 Bot.prototype.sendLocation = function (options, callback) {
   var self = this
     , deferred = Q.defer();
@@ -696,17 +535,6 @@ Bot.prototype.sendLocation = function (options, callback) {
   return deferred.promise.nodeify(callback);
 };
 
-/**
- * Use this method when you need to tell the user that something is happening on the bot's side.
- * 
- * @param {Object}              options           Options
- * @param {Integer}             options.chat_id   Unique identifier for the message recipient — User or GroupChat id
- * @param {String}              options.action    Type of action to broadcast.
- * @param {Bot~requestCallback} callback          The callback that handles the response.
- * @return {Promise}  Q Promise
- *
- * @see https://core.telegram.org/bots/api#sendchataction
- */
 Bot.prototype.sendChatAction = function (options, callback) {
   var self = this
     , deferred = Q.defer();

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -94,7 +94,7 @@ Bot.prototype._poll = function () {
 		        {
 			        var arguments = msg.message.text.split(' ');
 			        arguments.shift();
-			        self.emit(command, arguments, msg.message);
+			        self.emit(command, msg.message, arguments);
 		        }
 		        else{
 			        self.emit(command, msg.message);

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -87,7 +87,7 @@ Bot.prototype._poll = function () {
         body.result.forEach(function (msg) {
           if (msg.update_id >= self.offset) {
             self.offset = msg.update_id + 1;
-	        if(msg.message.text.charAt(0) === '/'){
+	        if(msg.message.text && msg.message.text.charAt(0) === '/'){
 		        var command = msg.message.text.split(' ', 2)[0];
 		        command = command.replace(/[^a-zA-Z0-9 ]/g, "");
 		        if(msg.message.text.split(' ')[1])
@@ -97,7 +97,7 @@ Bot.prototype._poll = function () {
 			        self.emit(command, arguments, msg.message);
 		        }
 		        else{
-			        self.emit(command, msg.message.text, msg.message);
+			        self.emit(command, msg.message);
 		        }
 	        }
             self.emit('message', msg.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-telegram-bot",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Telegram Bot API Wrapper for nodejs",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Bot was crashing when i.e. added to the group because of split() error with that service message. This is fixed.
Also bot now returns any number of arguments for command as an array.