### PR TITLE
Unncessary check for file types when file_id is provided

### DIFF
--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -397,11 +397,6 @@ Bot.prototype.sendAudio = function (options, callback) {
   var self = this
     , deferred = Q.defer();
 
-  if (mime.lookup(options.files.audio) !== 'audio/ogg') {
-    return Q.reject(new Error('Invalid file type'))
-    .nodeify(callback);
-  }
-
   if (options.file_id) {
     this._get({ 
       method: 'sendAudio',
@@ -423,6 +418,11 @@ Bot.prototype.sendAudio = function (options, callback) {
       }
     });
   } else {
+    if (mime.lookup(options.files.audio) !== 'audio/ogg') {
+      return Q.reject(new Error('Invalid file type'))
+      .nodeify(callback);
+    }
+
     this._multipart({
       method: 'sendAudio',
       params: {
@@ -532,11 +532,6 @@ Bot.prototype.sendSticker = function (options, callback) {
   var self = this
     , deferred = Q.defer();
 
-  if (mime.lookup(options.files.sticker) !== 'image/webp') {
-    return Q.reject(new Error('Invalid file type'))
-    .nodeify(callback);
-  }
-
   if (options.file_id) {
     this._get({ 
       method: 'sendSticker',
@@ -558,6 +553,11 @@ Bot.prototype.sendSticker = function (options, callback) {
       }
     });
   } else {
+    if (mime.lookup(options.files.sticker) !== 'image/webp') {
+      return Q.reject(new Error('Invalid file type'))
+      .nodeify(callback);
+    }
+
     this._multipart({
       method: 'sendSticker',
       params: {
@@ -602,11 +602,6 @@ Bot.prototype.sendVideo = function (options, callback) {
   var self = this
     , deferred = Q.defer();
 
-  if (mime.lookup(options.files.video.filename) !== 'video/mp4') {
-    return Q.reject(new Error('Invalid file type'))
-    .nodeify(callback);
-  }
-
   if (options.file_id) {
     this._get({ 
       method: 'sendSticker',
@@ -628,6 +623,11 @@ Bot.prototype.sendVideo = function (options, callback) {
       }
     });
   } else {
+    if (mime.lookup(options.files.video.filename) !== 'video/mp4') {
+      return Q.reject(new Error('Invalid file type'))
+      .nodeify(callback);
+    }
+    
     this._multipart({
       method: 'sendVideo',
       params: {


### PR DESCRIPTION
Moved a check for file type in sendAudio, sendSticker and sendVideo that
was preventing the use of the methods providing only a file_id without a
reference to a local file.