### PR TITLE
Misc bugfixes; includes fix for _multipart JSON parsing

### DIFF
--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -95,6 +95,16 @@ Bot.prototype._multipart = function (options, callback) {
           callback(err);
         }
       } else {
+        var contentType = res.headers['content-type'];
+
+        if (contentType.indexOf('application/json') >= 0) {
+          try {
+            body = JSON.parse(body);
+          } catch (e) {
+            callback(e, body);
+          }
+        }
+
         callback(null, body);
       }
     });

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -1,4 +1,5 @@
 var EventEmitter = require('events').EventEmitter
+  , debug = require('debug')('node-telegram-bot')
   , util = require('util')
   , request = require('request')
   , fs = require('fs')
@@ -159,14 +160,14 @@ Bot.prototype._setWebhook = function (webhook) {
   }, function (err, res, body) {
     if (!err && res.statusCode === 200) {
       if (body.ok) {
-      	console.log("Set webhook to " + self.webhook);
+      	debug("Set webhook to " + self.webhook);
 			} else {
-				console.log("Body not ok");
-				console.log(body);
+				debug("Body not ok");
+				debug(body);
 			}
     } else {
-			console.log(err);
-			console.log("Failed to set webhook with code" + res.statusCode);
+			debug(err);
+			debug("Failed to set webhook with code" + res.statusCode);
 		}
   });
 }

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -138,7 +138,7 @@ Bot.prototype._multipart = function (options, callback) {
       contentType: contentType
     });
 
-    Object.keys(options.params).forEach(function(key) {
+    Object.keys(options.params).forEach(function (key) {
       if (options.params[key]) {
         form.append(key, options.params[key]);
       }
@@ -194,16 +194,14 @@ Bot.prototype._poll = function () {
             self.offset = msg.update_id + 1;
 
             if (self.parseCommand) {
-              if(msg.message.text && msg.message.text.charAt(0) === '/'){
+              if (msg.message.text && msg.message.text.charAt(0) === '/') {
                 var command = msg.message.text.split(' ', 2)[0];
                 command = command.replace(/[^a-zA-Z0-9 ]/g, "");
-                if(msg.message.text.split(' ')[1])
-                {
+                if (msg.message.text.split(' ')[1]) {
                   var arguments = msg.message.text.split(' ');
                   arguments.shift();
                   self.emit(command, msg.message, arguments);
-                }
-                else{
+                } else{
                   self.emit(command, msg.message);
                 }
               }

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -33,7 +33,7 @@ function Bot(options) {
   this.parseCommand = options.parseCommand ? options.parseCommand : true;
   this.maxAttempts = options.maxAttempts ? options.maxAttempts : 5;
   this.polling = false;
-  this.base_url = 'https://api.telegram.org/bot'
+  this.base_url = 'https://api.telegram.org/bot';
 }
 
 util.inherits(Bot, EventEmitter);
@@ -185,7 +185,9 @@ Bot.prototype._poll = function () {
     url: url,
     json: true
   }, function (err, res, body) {
-    if (!err && res.statusCode === 200) {
+    if (err) {
+      self.emit('error', err);
+    } else if (res.statusCode === 200) {
       if (body.ok) {
         body.result.forEach(function (msg) {
           if (msg.update_id >= self.offset) {
@@ -211,7 +213,7 @@ Bot.prototype._poll = function () {
           }
         });
       }
-    } else if(res.statusCode === 401){
+    } else if (res.statusCode === 401) {
       self.emit('error', 'Invalid token');
     }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/depoio/node-telegram-bot#readme",
   "dependencies": {
+    "debug": "^2.2.0",
     "mime": "^1.3.4",
     "q": "^1.4.1",
     "request": "^2.58.0"


### PR DESCRIPTION
@shernshiou all the _multiparts actually return application/json data and the method sendPhoto/Audio/etc calls return an err; the reason you haven't run into it is because the example sendPhoto call prints out the result and doesn't try to use it (e.g., the promise actually gets rejected).

Also removed some extraneous console.log statements and replaced with the optional `debug` utility so dependent authors don't have to have console.logs there if they don't want.

Last change was fixing a bug in Bot._poll which arises if there's an HTTP error in the long-poll request.  I encountered this while paused for awhile in the debugger, but it could happen due to normal transport errors as well.