### PR TITLE
Fix for command parsing (#45)

### DIFF
--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -221,30 +221,21 @@ Bot.prototype._poll = function () {
                 if (msg.message.text && msg.message.text.charAt(0) === '/') {
                   /**
                    * Split the message on space and @
+                   * Zero part = complete message
                    * First part = command with leading /
-                   * Second part = target or arguments
-                   * Third part = arguments if target is available
+                   * Third part = target or empty ""
+                   * Fourth part = arguments or empty ""
                    */
+                  var messageParts = msg.message.text.match(/([^@ ]*)([^ ]*)[ ]?(.*)/);
 
-                  var messageParts = msg.message.text.split(/[ @]/, 3);
+                  // Filter everything not alphaNum out of the command
+                  var command = messageParts[1].replace(/[^a-zA-Z0-9 ]/g, "");
+                  // Target incl @ sign or null
+                  var target = (messageParts[2] !== "" ? messageParts[2]: null);
+                  // Optional arguments or null
+                  var args = (messageParts[3] !== "" ? messageParts[3].split(' '): null);
 
-                  // Filter everything not alphanum out of the command
-                  var command = messageParts[0].replace(/[^a-zA-Z0-9 ]/g, "");
-
-                  // Check length of messageParts
-                  // length 1: command
-                  // length 2: command + arguments
-                  // length 3: command + target + arguments
-                  var arg = '';
-                  if (messageParts.length == 3) {
-                    arg = messageParts[2].split(' ');
-                    self.emit(command, msg.message, arg);
-                  } else if (messageParts.length == 2) {
-                    arg = messageParts[1].split(' ');
-                    self.emit(command, msg.message, arg);
-                  } else {
-                    self.emit(command, msg.message);
-                  }
+                  self.emit(command, msg.message, args, target);
                 }
               }
 

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -219,13 +219,30 @@ Bot.prototype._poll = function () {
 
               if (self.parseCommand) {
                 if (msg.message.text && msg.message.text.charAt(0) === '/') {
-                  var command = msg.message.text.split(' ', 2)[0];
-                  command = command.replace(/[^a-zA-Z0-9 ]/g, "");
-                  if (msg.message.text.split(' ')[1]) {
-                    var arg = msg.message.text.split(' ');
-                    arg.shift();
+                  /**
+                   * Split the message on space and @
+                   * First part = command with leading /
+                   * Second part = target or arguments
+                   * Third part = arguments if target is available
+                   */
+
+                  var messageParts = msg.message.text.split(/[ @]/, 3);
+
+                  // Filter everything not alphanum out of the command
+                  var command = messageParts[0].replace(/[^a-zA-Z0-9 ]/g, "");
+
+                  // Check length of messageParts
+                  // length 1: command
+                  // length 2: command + arguments
+                  // length 3: command + target + arguments
+                  var arg = '';
+                  if (messageParts.length == 3) {
+                    arg = messageParts[2].split(' ');
                     self.emit(command, msg.message, arg);
-                  } else{
+                  } else if (messageParts.length == 2) {
+                    arg = messageParts[1].split(' ');
+                    self.emit(command, msg.message, arg);
+                  } else {
                     self.emit(command, msg.message);
                   }
                 }


### PR DESCRIPTION
I think this is a way to fix #45 

Possible command messages for as far as I can see:
/command
/command arg [..] arg
/command@botname
/command@botname arg [..] arg

Instead of splitting the 'command' on "@" or space you can use a regexp to split in one time in three possible parts:
- Command (e.g. /image)
- Target (e.g. @botname)
- arguments (can be multiple) (e.g. 'hello there') 

After that nullify the parts that are matched as empty string and pass everything as self.emit. Note: I've added a fourth argument 'target' to the emit call, passing the @botname to the listening application. The application should handle the target if required (match to botname, or do something else like aim a command to a user, etc).

Hope you like the fix :)