### PR TITLE
Further commits to improve 409 duplicate token problems

### DIFF
--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -34,7 +34,7 @@ function Bot(options) {
   this.maxAttempts = options.maxAttempts ? options.maxAttempts : 5;
   this.polling = false;
   this.analytics = null;
-  this.timeout = options.timeout ? options.timeout : 60000;
+  this.timeout = options.timeout ? options.timeout : 60; //specify in seconds
 }
 
 util.inherits(Bot, EventEmitter);
@@ -196,14 +196,14 @@ Bot.prototype._setWebhook = function (webhook) {
  */
 Bot.prototype._poll = function () {
   var self = this;
-  var url = this.base_url + 'bot' + this.token + '/getUpdates?timeout=60&offset=' + this.offset;
+  var url = this.base_url + 'bot' + this.token + '/getUpdates?timeout=' + this.timeout + '&offset=' + this.offset;
 
   if (self.polling) {
     debug("Poll");
 
     request.get({
       url: url,
-      timeout: this.timeout,
+      timeout: this.timeout * 1000,
       json: true
     }, function (err, res, body) {
 

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -210,8 +210,6 @@ Bot.prototype._poll = function () {
       if (err && err.code !== 'ETIMEDOUT') {
         self.emit('error', err);
       } else if (res.statusCode === 200) {
-        self._poll();
-
         if (body.ok) {
           body.result.forEach(function (msg) {
             if (msg.update_id >= self.offset) {
@@ -247,6 +245,11 @@ Bot.prototype._poll = function () {
             }
           });
         }
+
+        setTimeout(function () {
+          self._poll();
+        }, self.interval);
+
       } else if(res && res.hasOwnProperty('statusCode') && res.statusCode === 401) {
         self.emit('error', new Error('Invalid token.'));
       } else if(res && res.hasOwnProperty('statusCode') && res.statusCode === 409) {
@@ -257,11 +260,6 @@ Bot.prototype._poll = function () {
         self.emit('error', new Error(util.format('Unknown error. Status code: %d', res.statusCode)));
       }
     });
-  } else {
-    debug('Stopped polling');
-    setTimeout(function () {
-      self._poll();
-    }, self.interval);
   }
 
   return this;
@@ -274,14 +272,12 @@ Bot.prototype._poll = function () {
  */
 Bot.prototype.start = function () {
   var self = this;
-
-	if (self.webhook) {
-		self._setWebhook(this.webhook);
-	} else if (!self.polling) {
-	  self._poll();
-  	self.polling = true;
-	}
-
+  if (self.webhook) {
+      self._setWebhook(this.webhook);
+  } else if (!self.polling) {
+      self.polling = true;
+      self._poll();
+  }
   return self;
 };
 
@@ -292,10 +288,7 @@ Bot.prototype.start = function () {
  */
 Bot.prototype.stop = function () {
   var self = this;
-
-	//self._setWebhook("");
   self.polling = false;
-
   return self;
 };
 

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -173,7 +173,7 @@ Bot.prototype._setWebhook = function (webhook) {
     url: url,
     json: true
   }, function (err, res, body) {
-    if (!err && res.statusCode === 200) {
+    if (!err && res && res.statusCode === 200) {
       if (body.ok) {
       	debug("Set webhook to " + self.webhook);
 			} else {
@@ -184,9 +184,9 @@ Bot.prototype._setWebhook = function (webhook) {
       debug(err);
       debug("Failed to set webhook with code" + res.statusCode);
     } else {
-			debug(err);
-			debug("Failed to set webhook with code" + res.statusCode);
-		}
+      debug(err);
+      debug("Failed to set webhook with unknown error");
+    }
   });
 }
 
@@ -211,7 +211,7 @@ Bot.prototype._poll = function () {
       self.pollingRequest = null;
       if (err && err.code !== 'ETIMEDOUT') {
         self.emit('error', err);
-      } else if (res.statusCode === 200) {
+      } else if (res && res.statusCode === 200) {
         if (body.ok) {
           body.result.forEach(function (msg) {
             if (msg.update_id >= self.offset) {
@@ -259,7 +259,7 @@ Bot.prototype._poll = function () {
       } else if(res && res.hasOwnProperty('statusCode') && res.statusCode === 502) {
         self.emit('error', new Error('Gateway error.'));
       } else {
-        self.emit('error', new Error(util.format('Unknown error. Status code: %d', res.statusCode)));
+        self.emit('error', new Error(util.format('Unknown error')));
       }
     });
   }

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -199,6 +199,7 @@ Bot.prototype._poll = function () {
   var self = this;
   var url = self.base_url + 'bot' + self.token + '/getUpdates?timeout=' + self.timeout + '&offset=' + self.offset;
 
+  self.pollingRequest = null;
   if (self.polling) {
     debug("Poll");
 
@@ -208,7 +209,6 @@ Bot.prototype._poll = function () {
       json: true
     }, function (err, res, body) {
 
-      self.pollingRequest = null;
       if (err && err.code !== 'ETIMEDOUT') {
         self.emit('error', err);
       } else if (res && res.statusCode === 200) {
@@ -258,7 +258,7 @@ Bot.prototype._poll = function () {
         self.emit('error', new Error('Duplicate token.'));
       } else if(res && res.hasOwnProperty('statusCode') && res.statusCode === 502) {
         self.emit('error', new Error('Gateway error.'));
-      } else {
+      } else if(self.pollingRequest && !self.pollingRequest._aborted) { //Skip error throwing, this is an abort due to stopping
         self.emit('error', new Error(util.format('Unknown error')));
       }
     });

--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -33,6 +33,7 @@ function Bot(options) {
   this.parseCommand = options.parseCommand ? options.parseCommand : true;
   this.maxAttempts = options.maxAttempts ? options.maxAttempts : 5;
   this.polling = false;
+  this.pollingRequest = null;
   this.analytics = null;
   this.timeout = options.timeout ? options.timeout : 60; //specify in seconds
 }
@@ -196,17 +197,18 @@ Bot.prototype._setWebhook = function (webhook) {
  */
 Bot.prototype._poll = function () {
   var self = this;
-  var url = this.base_url + 'bot' + this.token + '/getUpdates?timeout=' + this.timeout + '&offset=' + this.offset;
+  var url = self.base_url + 'bot' + self.token + '/getUpdates?timeout=' + self.timeout + '&offset=' + self.offset;
 
   if (self.polling) {
     debug("Poll");
 
-    request.get({
+    self.pollingRequest = request.get({
       url: url,
-      timeout: this.timeout * 1000,
+      timeout: self.timeout * 1000,
       json: true
     }, function (err, res, body) {
 
+      self.pollingRequest = null;
       if (err && err.code !== 'ETIMEDOUT') {
         self.emit('error', err);
       } else if (res.statusCode === 200) {
@@ -246,9 +248,9 @@ Bot.prototype._poll = function () {
           });
         }
 
-        setTimeout(function () {
-          self._poll();
-        }, self.interval);
+        if (self.polling) {
+            self._poll();
+        }
 
       } else if(res && res.hasOwnProperty('statusCode') && res.statusCode === 401) {
         self.emit('error', new Error('Invalid token.'));
@@ -262,7 +264,7 @@ Bot.prototype._poll = function () {
     });
   }
 
-  return this;
+  return self;
 };
 
 /**
@@ -289,6 +291,9 @@ Bot.prototype.start = function () {
 Bot.prototype.stop = function () {
   var self = this;
   self.polling = false;
+  if (self.pollingRequest) {
+      self.pollingRequest.abort();
+  }
   return self;
 };
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "Chin Ning Gan <chinning.gan@gmail.com>"
   ],
   "contributors": [
-    "Alberto Bottarini <alberto.bottarini@gmail.com> (http://www.albertobottarini.com)"
+    "Alberto Bottarini <alberto.bottarini@gmail.com> (http://www.albertobottarini.com)",
+    "Sebastian Arena <sarena@mobile-tonic.com> (http://mobile-tonic.com)"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
It seems to me pointless to keep retrying polling if the user decided to stop. This is generating a ton of problems on my side, and stopping the infinite polling when unneeded seems to work (will continue to test on production thru the day).

Also, I took your new option for timeout and added it to getUpdates.