### PR TITLE
fix type message undefined error(temporary solution...)

### DIFF
--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -218,7 +218,7 @@ Bot.prototype._poll = function () {
               self.offset = msg.update_id + 1;
 
               if (self.parseCommand) {
-                if (msg.message.text && msg.message.text.charAt(0) === '/') {
+                if (msg.message && msg.message.text && msg.message.text.charAt(0) === '/') {
                   /**
                    * Split the message on space and @
                    * Zero part = complete message


### PR DESCRIPTION
https://core.telegram.org/bots/api#update
when receiving getUpdates from telegram it will reply in one of optional field below:
message,edited_message,inline_query,chosen_inline_result,callback_query
So far this lib only support message and do not expect other type field. This quick patch will fix crash issue when it receive field other than message.

But add support for other type of update field still needed. This is just a quick fix for not crashing the lib.